### PR TITLE
Add --format option

### DIFF
--- a/lib/metadata_json_lint.rb
+++ b/lib/metadata_json_lint.rb
@@ -8,11 +8,13 @@ module MetadataJsonLint
     @options ||= Struct.new(
       :fail_on_warnings,
       :strict_license,
-      :strict_dependencies
+      :strict_dependencies,
+      :format,
     ).new(
       true, # fail_on_warnings
       true, # strict_license
-      false # strict_dependencies
+      false, # strict_dependencies
+      'text', # format
     )
   end
   module_function :options
@@ -32,6 +34,10 @@ module MetadataJsonLint
       opts.on('--[no-]fail-on-warnings', "Fail on any warnings. Defaults to '#{options[:fail_on_warnings]}'.") do |v|
         options[:fail_on_warnings] = v
       end
+
+      opts.on("-f", "--format FORMAT", [:text, :json], "The format in which results will be output (text, json)") do |format|
+        options[:format] = format
+      end
     end.parse!
 
     mj = if ARGV[0].nil?
@@ -49,6 +55,9 @@ module MetadataJsonLint
   module_function :run
 
   def parse(metadata)
+    @errors = []
+    @warnings = []
+
     # Small hack to use the module settings as defaults but allow overriding for different rake tasks
     options = options().clone
     # Configuration from rake tasks
@@ -65,82 +74,96 @@ module MetadataJsonLint
       abort("Error: Unable to parse metadata.json: #{e.exception}")
     end
 
-    error_state = false
-
     # Fields required to be in metadata.json
     # From: https://docs.puppetlabs.com/puppet/latest/reference/modules_publishing.html#write-a-metadatajson-file
     required_fields = %w(name version author license summary source dependencies)
     required_fields.each do |field|
       if parsed[field].nil?
-        puts "Error: Required field '#{field}' not found in metadata.json."
-        error_state = true
+        error :required_fields, "Required field '#{field}' not found in metadata.json."
       end
     end
 
-    error_state ||= invalid_dependencies?(parsed['dependencies']) if parsed['dependencies']
+    validate_dependencies!(parsed['dependencies']) if parsed['dependencies']
 
     # Deprecated fields
     # From: https://docs.puppetlabs.com/puppet/latest/reference/modules_publishing.html#write-a-metadatajson-file
     deprecated_fields = %w(types checksum)
     deprecated_fields.each do |field|
       unless parsed[field].nil?
-        puts "Error: Deprecated field '#{field}' found in metadata.json."
-        error_state = true
+        error :deprecated_fields, "Deprecated field '#{field}' found in metadata.json."
       end
     end
 
     # The nested 'requirements' name of 'pe' is deprecated as well.
     # https://groups.google.com/forum/?utm_medium=email&utm_source=footer#!msg/puppet-users/nkRPvG4q0Oo/GmXa109aJQAJ
-    error_state ||= invalid_requirements?(parsed['requirements']) if parsed['requirements']
+    validate_requirements!(parsed['requirements']) if parsed['requirements']
 
     # Summary can not be over 144 characters:
     # From: https://forge.puppetlabs.com/razorsedge/snmp/3.3.1/scores
     if !parsed['summary'].nil? && parsed['summary'].size > 144
-      puts 'Error: summary exceeds 144 characters in metadata.json.'
-      error_state = true
+      error :summary, 'Field \'summary\' exceeds 144 characters in metadata.json.'
     end
 
     # Shoulds/recommendations
     # From: https://docs.puppetlabs.com/puppet/latest/reference/modules_publishing.html#write-a-metadatajson-file
     #
     if !parsed['license'].nil? && !SpdxLicenses.exist?(parsed['license']) && parsed['license'] != 'proprietary'
-      puts "Warning: License identifier #{parsed['license']} is not in the SPDX list: http://spdx.org/licenses/"
-      error_state = true if options[:strict_license]
+      msg = "License identifier #{parsed['license']} is not in the SPDX list: http://spdx.org/licenses/"
+
+      if options[:strict_license]
+        error :license, msg
+      else
+        warn :license, msg
+      end
     end
 
     if !parsed['tags'].nil? && !parsed['tags'].is_a?(Array)
-      puts "Warning: Tags must be in an array. Currently it's a #{parsed['tags'].class}."
-      error_state = true
+      error :tags, "Tags must be in an array. Currently it's a #{parsed['tags'].class}."
     end
 
-    return unless error_state
-    if options[:fail_on_warnings] == true
-      abort("Errors found in #{metadata}")
-    else
-      puts "Errors found in #{metadata}"
+    if @errors.size > 0 || @warnings.size > 0
+      if @errors.size > 0
+        result = "Errors found in #{metadata}"
+      else
+        result = "Warnings found in #{metadata}"
+      end
+
+      case options[:format]
+      when :json
+        puts JSON.fast_generate({
+          :result => result,
+          :warnings => @warnings,
+          :errors => @errors,
+        })
+      else
+        @warnings.each { |warn| puts "(WARN) #{warn}" }
+        @errors.each { |err| puts "(ERROR) #{err}" }
+        puts result
+      end
+
+      if @errors.size > 0 || (@warnings.size > 0 && (options[:fail_on_warnings] == true))
+        exit(1)
+      end
     end
+
+    exit(0)
   end
   module_function :parse
 
-  def invalid_requirements?(requirements)
-    error_state = false
+  def validate_requirements!(requirements)
     requirements.each do |requirement|
       if requirement['name'] == 'pe'
-        puts "The 'pe' requirement is no longer supported by the Forge."
-        error_state = true
+        warn :requirements, "The 'pe' requirement is no longer supported by the Forge."
       end
     end
-    error_state
   end
-  module_function :invalid_requirements?
+  module_function :validate_requirements!
 
-  def invalid_dependencies?(deps)
-    error_state = false
+  def validate_dependencies!(deps)
     dep_names = []
     deps.each do |dep|
       if dep_names.include?(dep['name'])
-        puts "Error: duplicate dependencies on #{dep['name']}"
-        error_state = true
+        warn :dependencies, "Duplicate dependencies on #{dep['name']}"
       end
       dep_names << dep['name']
 
@@ -148,28 +171,55 @@ module MetadataJsonLint
       # From: https://docs.puppet.com/puppet/latest/reference/modules_metadata.html#best-practice-set-an-upper-bound-for-dependencies
       begin
         next unless dep['version_requirement'].nil? || open_ended?(dep['version_requirement'])
-        puts "Warning: Dependency #{dep['name']} has an open " \
+
+        msg = "Dependency #{dep['name']} has an open " \
           "ended dependency version requirement #{dep['version_requirement']}"
-        error_state = true if options[:strict_dependencies]
+
+        if options[:strict_dependencies]
+          error :dependencies, msg
+        else
+          warn :dependencies, msg
+        end
       rescue ArgumentError => e
         # Raised when the version_requirement provided could not be parsed
-        puts "Invalid 'version_requirement' field in metadata.json: #{e}"
-        error_state = true
+        error :dependencies, "Invalid 'version_requirement' field in metadata.json: #{e}"
       end
 
       # 'version_range' is no longer used by the forge
       # See https://tickets.puppetlabs.com/browse/PUP-2781
       next unless dep['version_range']
-      puts "Warning: Dependency #{dep['name']} has a 'version_range' attribute " \
+      warn :dependencies, "Dependency #{dep['name']} has a 'version_range' attribute " \
         'which is no longer used by the forge.'
-      error_state = true
     end
-    error_state
   end
-  module_function :invalid_dependencies?
+  module_function :validate_dependencies!
 
   def open_ended?(module_end)
     SemanticPuppet::VersionRange.parse(module_end).end == SemanticPuppet::Version::MAX
   end
   module_function :open_ended?
+
+  def format_error(check, msg)
+    return case options[:format]
+    when :json
+      { :check => check, :msg => msg }
+    else
+      "#{check}: #{msg}"
+    end
+  end
+  module_function :format_error
+
+  def warn(check, msg)
+    @warnings ||= []
+
+    @warnings << format_error(check, msg)
+  end
+  module_function :warn
+
+  def error(check, msg)
+    @errors ||= []
+
+    @errors << format_error(check, msg)
+  end
+  module_function :error
 end

--- a/tests/bad_license/expected
+++ b/tests/bad_license/expected
@@ -1,1 +1,1 @@
-Warning: License identifier Unknown-1.0 is not in the SPDX list: http://spdx.org/licenses/
+License identifier Unknown-1.0 is not in the SPDX list: http://spdx.org/licenses/

--- a/tests/duplicate-dep/expected
+++ b/tests/duplicate-dep/expected
@@ -1,1 +1,1 @@
-Error: duplicate dependencies on puppetlabs/stdlib
+Duplicate dependencies on puppetlabs/stdlib

--- a/tests/json_format/Rakefile
+++ b/tests/json_format/Rakefile
@@ -1,0 +1,2 @@
+$LOAD_PATH.unshift(File.expand_path('../../../lib', __FILE__))
+require 'metadata-json-lint/rake_task'

--- a/tests/json_format/expected
+++ b/tests/json_format/expected
@@ -1,0 +1,1 @@
+"errors":[{"check":"license","msg":"License identifier Unknown-1.0 is not in the SPDX list: http://spdx.org/licenses/"}]

--- a/tests/json_format/metadata.json
+++ b/tests/json_format/metadata.json
@@ -1,0 +1,83 @@
+{
+  "name": "puppetlabs-postgresql",
+  "version": "3.4.1",
+  "author": "Inkling/Puppet Labs",
+  "summary": "PostgreSQL defined resource types",
+  "license": "Unknown-1.0",
+  "source": "git://github.com/puppetlabs/puppet-postgresql.git",
+  "project_page": "https://github.com/puppetlabs/puppet-postgresql",
+  "issues_url": "https://github.com/puppetlabs/puppet-postgresql/issues",
+  "operatingsystem_support": [
+    {
+      "operatingsystem": "RedHat",
+      "operatingsystemrelease": [
+        "5",
+        "6",
+        "7"
+      ]
+    },
+    {
+      "operatingsystem": "CentOS",
+      "operatingsystemrelease": [
+        "5",
+        "6",
+        "7"
+      ]
+    },
+    {
+      "operatingsystem": "OracleLinux",
+      "operatingsystemrelease": [
+        "5",
+        "6",
+        "7"
+      ]
+    },
+    {
+      "operatingsystem": "Scientific",
+      "operatingsystemrelease": [
+        "5",
+        "6",
+        "7"
+      ]
+    },
+    {
+      "operatingsystem": "Debian",
+      "operatingsystemrelease": [
+        "6",
+        "7"
+      ]
+    },
+    {
+      "operatingsystem": "Ubuntu",
+      "operatingsystemrelease": [
+        "10.04",
+        "12.04",
+        "14.04"
+      ]
+    }
+  ],
+  "requirements": [
+    {
+      "name": "puppet",
+      "version_requirement": "3.x"
+    }
+  ],
+  "dependencies": [
+    {
+      "name": "puppetlabs/stdlib",
+      "version_requirement": "4.x"
+    },
+    {
+      "name": "puppetlabs/firewall",
+      "version_requirement": ">= 0.0.4"
+    },
+    {
+      "name": "puppetlabs/apt",
+      "version_requirement": ">=1.1.0 <2.0.0"
+    },
+    {
+      "name": "puppetlabs/concat",
+      "version_requirement": ">= 1.1.0 <2.0.0"
+    }
+  ]
+}

--- a/tests/long_summary/expected
+++ b/tests/long_summary/expected
@@ -1,1 +1,1 @@
-Error: summary exceeds 144 characters in metadata.json
+Field 'summary' exceeds 144 characters in metadata.json

--- a/tests/missing_version_requirement/expected
+++ b/tests/missing_version_requirement/expected
@@ -1,1 +1,1 @@
-Warning: Dependency puppetlabs/stdlib has an open ended dependency version requirement
+Dependency puppetlabs/stdlib has an open ended dependency version requirement

--- a/tests/multiple_problems/expected
+++ b/tests/multiple_problems/expected
@@ -1,3 +1,3 @@
-Error: Required field 'license' not found in metadata.json.
-Error: Required field 'summary' not found in metadata.json.
-Error: Deprecated field 'types' found in metadata.json.
+Required field 'license' not found in metadata.json.
+Required field 'summary' not found in metadata.json.
+Deprecated field 'types' found in metadata.json.

--- a/tests/noname/expected
+++ b/tests/noname/expected
@@ -1,1 +1,1 @@
-Error: Required field 'name' not found in metadata.json.
+Required field 'name' not found in metadata.json.

--- a/tests/open_ended_dependency/expected
+++ b/tests/open_ended_dependency/expected
@@ -1,1 +1,1 @@
-Warning: Dependency puppetlabs/stdlib has an open ended dependency version requirement >= 3.2.0
+Dependency puppetlabs/stdlib has an open ended dependency version requirement >= 3.2.0

--- a/tests/rake_global_options/Rakefile
+++ b/tests/rake_global_options/Rakefile
@@ -1,3 +1,4 @@
 $LOAD_PATH.unshift(File.expand_path('../../../lib', __FILE__))
 require 'metadata-json-lint/rake_task'
 MetadataJsonLint.options.strict_license = false
+MetadataJsonLint.options.fail_on_warnings = false

--- a/tests/rake_global_options/expected
+++ b/tests/rake_global_options/expected
@@ -1,1 +1,1 @@
-Warning: License identifier invalid_license is not in the SPDX list: http://spdx.org/licenses/
+License identifier invalid_license is not in the SPDX list: http://spdx.org/licenses/

--- a/tests/tags_no_array/expected
+++ b/tests/tags_no_array/expected
@@ -1,1 +1,1 @@
-Warning: Tags must be in an array. Currently it's a String.
+Tags must be in an array. Currently it's a String.

--- a/tests/test.sh
+++ b/tests/test.sh
@@ -42,7 +42,7 @@ test_bin() {
       echo "Successful Test '${name}' (bin)"
     else
       if [ -f expected ]; then
-        if grep --quiet "`cat expected`" last_output; then
+        if grep -F --quiet -f expected last_output; then
           echo "Successful Test '${name}' (bin)"
         else
           fail "Failing Test '${name}' (did not get expected output) (bin)"
@@ -131,6 +131,9 @@ test "tags_with_array" $SUCCESS
 
 # Run with tags not in an array in metadata.json, expect FAILURE
 test "tags_no_array" $FAILURE
+
+# Run with json output format
+test "json_format" $FAILURE --format json
 
 # Test running without specifying file to parse
 cd perfect

--- a/tests/test.sh
+++ b/tests/test.sh
@@ -99,7 +99,7 @@ test "duplicate-dep" $SUCCESS --no-fail-on-warnings
 # Run a broken one, expect FAILURE
 test "bad_license" $FAILURE
 # Run with --no-strict-license, expect SUCCESS
-test "bad_license" $SUCCESS --no-strict-license
+test "bad_license" $SUCCESS --no-strict-license --no-fail-on-warnings
 
 # Run a broken one, expect FAILURE
 test "long_summary" $FAILURE
@@ -111,12 +111,12 @@ test "mixed_version_syntax" $FAILURE
 test "no_dependencies" $SUCCESS
 
 # Run one with open ended dependency, expect SUCCESS
-test "open_ended_dependency" $SUCCESS
+test "open_ended_dependency" $SUCCESS --no-fail-on-warnings
 # Run one with open ended dependency and --strict-dependencies, expect FAILURE
 test "open_ended_dependency" $FAILURE --strict-dependencies
 
 # Run one with missing version_requirement and --no-strict-dependency, expect SUCCESS
-test "missing_version_requirement" $SUCCESS
+test "missing_version_requirement" $SUCCESS --no-fail-on-warnings
 # Run one with open ended dependency and --strict-dependencies, expect FAILURE
 test "missing_version_requirement" $FAILURE --strict-dependencies
 

--- a/tests/types/expected
+++ b/tests/types/expected
@@ -1,1 +1,1 @@
-Error: Deprecated field 'types' found in metadata.json.
+Deprecated field 'types' found in metadata.json.


### PR DESCRIPTION
Adds a --format (-f) option to control the output format of errors and
warnings. Valid values for --format are 'text' (the default) and 'json'.
The 'text' format is similar to the previous format but slightly more
structured. 'json' format is brand new.

Tests have been updated to match against the slight changes to 'text'
output format as well as resolving some minor inconsistencies in which
checks would result in a non-zero exit status.

Due to the more consistent behavior around exit status, these changes
are not strictly backwards compatible.